### PR TITLE
Fix tier list sorting issue when tier is removed

### DIFF
--- a/js/tiers.js
+++ b/js/tiers.js
@@ -928,7 +928,8 @@ function removeTier(sourceTierNum, skipConfirmation, noDisplay) {
                 const removedItems = removeCharacters(tierNum);
                 copyTierSettings(tierList, prevTierNum, tierNum);
 
-                for (const item of removedItems) {
+                for (let i = removedItems.length - 1; i >= 0; i--) {
+                    const item = removedItems[i];
                     addToTier(item, prevTierNum);
                 }
             } else { // noDisplay


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Fixed a bug where removing a tier caused all tiers below it to be sorted in reverse order.
